### PR TITLE
Adding tag v0.1.4 on hubot container

### DIFF
--- a/3. Installation/3. Docker Containers/README.md
+++ b/3. Installation/3. Docker Containers/README.md
@@ -275,7 +275,7 @@ rocketchat:
     - 3000:3000
 
 hubot:
-  image: rocketchat/hubot-rocketchat
+  image: rocketchat/hubot-rocketchat:v0.1.4
   environment:
     - ROCKETCHAT_URL=165.114.165.21:3000
     - ROCKETCHAT_ROOM=GENERAL


### PR DESCRIPTION
Latest tag was built using version v1.x.x of adapter and it is experimental, and in anticipation of a performance oriented sweeping change within the core - which has not happened yet.